### PR TITLE
Gradle run fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,4 +37,8 @@ test {
     systemProperty "file.encoding", "utf-8"
 }
 
+run {
+    standardInput = System.in
+}
+
 compileJava.options.encoding = 'UTF-8'


### PR DESCRIPTION
Wenn man das Projekt bisher in einer unveränderten Variante mit gradle run gestartet hat, hat der Scanner in Main.java nicht gewartet und das Programm ist abgestürtzt. Dies ließ sich durch eine Änderung in der Run configuration beheben.

## Checklist

 - [ ✅ ] Read [Contribution Guidelines](https://github.com/SlimeCloud/java-SlimeBot#contributing)
 - [ ✅ ] Tested the Code
 - [ ✅ ] This PR is ready to review and merge

## Description:
In build.gradle für die Task run den Standard output auf System.in gesetzt

## Related Issue
```
Exception in thread "main" java.util.NoSuchElementException: No line found
	at java.base/java.util.Scanner.nextLine(Scanner.java:1656)
	at com.slimebot.main.Main.main(Main.java:73)
```

## Other Information
Der Stackoverflow post mit der Lösung: https://stackoverflow.com/questions/36723447/java-util-scanner-throws-nosuchelementexception-when-application-is-started-with