### PR TITLE
Use Message#getJumpUrl instead of manual building

### DIFF
--- a/src/main/java/com/slimebot/report/contextmenus/MsgReport.java
+++ b/src/main/java/com/slimebot/report/contextmenus/MsgReport.java
@@ -39,15 +39,11 @@ public class MsgReport extends ListenerAdapter {
 
         String msg = event.getTarget().getContentRaw();
 
-        if ( msg.length() > 800) {
-            msg = msg.substring(0,800) + "...";
+        if (msg.length() > 800) {
+            msg = msg.substring(0, 800) + "...";
         }
 
-        String GuildId = event.getGuild().getId();
-        String ChannelId = event.getChannel().getId();
-        String MessageId = event.getTarget().getId();
-
-        String msgWithLink = "[" + msg + "](https://discord.com/channels/"+GuildId+"/"+ChannelId+"/"+MessageId+")";
+        String msgWithLink = "[" + msg + "](" + event.getTarget().getJumpUrl() + ")";
 
         Report.save(event.getGuild().getId(), Report.newReport(reportID, Type.MSG, event.getTarget().getMember(), event.getMember(), msgWithLink));
 


### PR DESCRIPTION
## Checklist

 - [x] Read [Contribution Guidelines](https://github.com/SlimeCloud/java-SlimeBot#contributing)
 - [x] Tested the Code
 - [x] This PR is ready to review and merge

## Description:
Small change that uses the Message#getJumpUrl method by JDA instead of manually building the jump URL by concatenating the ids of guild, channel and message.

## Related Issue
N/A

## Other Information
N/A