### PR TITLE
Make command reply ephemeral in Info ReportModal and MsgReport.

### DIFF
--- a/src/main/java/com/slimebot/commands/Info.java
+++ b/src/main/java/com/slimebot/commands/Info.java
@@ -28,6 +28,6 @@ public class Info extends ListenerAdapter {
                 .addField("Prefix:", "Dieser Bot nutzt Slash Commands", true)
                 .setFooter("SlimeBall", "https://media.discordapp.net/attachments/1098639892608712714/1098639949592539166/SlimeBall.png");
 
-        event.replyEmbeds(embedBuilder.build()).queue();
+        event.replyEmbeds(embedBuilder.build()).setEphemeral(true).queue();
     }
 }

--- a/src/main/java/com/slimebot/report/contextmenus/MsgReport.java
+++ b/src/main/java/com/slimebot/report/contextmenus/MsgReport.java
@@ -52,7 +52,7 @@ public class MsgReport extends ListenerAdapter {
                 .setColor(Main.embedColor(event.getGuild().getId()))
                 .setTitle(":white_check_mark: Report Erfolgreich")
                 .setDescription(event.getTarget().getAuthor().getAsMention() + " wurde erfolgreich gemeldet");
-        event.replyEmbeds(embedBuilder.build()).queue();
+        event.replyEmbeds(embedBuilder.build()).setEphemeral(true).queue();
         Report.log(reportID, event.getGuild().getId());
 
 

--- a/src/main/java/com/slimebot/report/modals/ReportModal.java
+++ b/src/main/java/com/slimebot/report/modals/ReportModal.java
@@ -59,7 +59,7 @@ public class ReportModal extends ListenerAdapter {
                 .setColor(Main.embedColor(event.getGuild().getId()))
                 .setTitle(":white_check_mark: Report Erfolgreich")
                 .setDescription(currentReport.getUser().getAsMention() + " wurde erfolgreich gemeldet");
-        event.replyEmbeds(embedBuilder.build()).queue();
+        event.replyEmbeds(embedBuilder.build()).setEphemeral(true).queue();
         Report.log(currentReport.getId(), event.getGuild().getId());
 
     }


### PR DESCRIPTION
## Checklist

 - [x] Read [Contribution Guidelines](https://github.com/SlimeCloud/java-SlimeBot#contributing)
 - [x] Tested the Code
 - [x] This PR is ready to review and merge

## Description
If a command replys non-ephemeral this can be quite annoying. This I why I made the reply in Info, ReportModal and MsgReport ephemeral. For ReportModal and MsgReport this also protects the identity of reporters in the public to avoid them being bullied by friends of the reported person. The reply in CloseReport was not made ephemeral to have the report closure logged in the moderator channel.

## Related Issue
N/A

## Other Information
N/A