### PR TITLE
Add commit hash to version string

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,17 +35,32 @@ dependencies {
     implementation 'com.github.MineKingBot:DiscordUtils:625de61'
 }
 
+String getVersion() {
+    var version = project.version.toString()
+
+    try {
+        var commit = 'git rev-parse --verify --short HEAD'.execute().text.trim()
+        version += "-" + commit
+    } catch(IOException ignore) {
+        version += "-unknown"
+    }
+
+    return version
+}
+
 tasks.register("prepareSources", Copy) {
     delete("$buildDir/preparedSources")
 
     from("src/main/java") {
         include("**/BuildInfo.java")
-        var tokens = Map.of(
-                "VERSION", version.toString()
-        )
 
-        filter(ReplaceTokens, "tokens": tokens)
+        filter(ReplaceTokens, "tokens":
+                Map.of(
+                        "VERSION", getVersion()
+                )
+        )
     }
+
     into("$buildDir/preparedSources")
 
     includeEmptyDirs = false


### PR DESCRIPTION
## Checklist

 - [x] Read [Contribution Guidelines](https://github.com/SlimeCloud/java-SlimeBot#-contributing) and [Style Guides](https://github.com/SlimeCloud/java-SlimeBot#-style-guide)
 - [x] Test the Code
 - [x] This PR is ready to review and merge

## Description
This adds the git commit hash to the version string. This makes it possible to see what exact version is running when looking at the log channel even if the version hasn't been updated

## Related Issue
N/A

## Other Information
N/A