### PR TITLE
Add Filter IMAGE_WITH_TEXT

### DIFF
--- a/src/main/java/com/slimebot/main/config/guild/AutoDeleteConfig.java
+++ b/src/main/java/com/slimebot/main/config/guild/AutoDeleteConfig.java
@@ -15,6 +15,7 @@ public class AutoDeleteConfig {
 	@Getter
 	public enum Filter {
 		IMAGE("Bilder", m -> m.getContentRaw().isEmpty() && !m.getAttachments().isEmpty() && m.getAttachments().stream().allMatch(Message.Attachment::isImage)),
+		IMAGE_WITH_TEXT("Beschriftete Bilder", m -> !m.getAttachments().isEmpty() && m.getAttachments().stream().allMatch(Message.Attachment::isImage)),
 		LINK("Links", m -> m.getAttachments().isEmpty() && Util.isValidURL(m.getContentRaw())),
 		INTEGER("Zahlen", m -> m.getAttachments().isEmpty() && Util.isInteger(m.getContentRaw()));
 


### PR DESCRIPTION
## Checklist

 - [x] Read [Contribution Guidelines](https://github.com/SlimeCloud/java-SlimeBot#-contributing) and [Style Guides](https://github.com/SlimeCloud/java-SlimeBot#-style-guide)
 - [x] Test the Code
 - [x] This PR is ready to review and merge

## Description
This adds a new auto delete filter "IMAGE_WITH_TEXT" (Beschriftete Bilder), that allows images that also have text in the message with is prohibited by the pure IMAGES filter

## Related Issue
N/A

## Other Information
N/A