### PR TITLE
Rankcard fix

### DIFF
--- a/src/main/java/com/slimebot/commands/level/RankCommand.java
+++ b/src/main/java/com/slimebot/commands/level/RankCommand.java
@@ -23,5 +23,4 @@ public class RankCommand {
 
 		event.getHook().sendFiles(new RankCard(Level.getLevel(user)).getFile()).queue();
 	}
-
 }

--- a/src/main/java/com/slimebot/commands/level/card/CardCommand.java
+++ b/src/main/java/com/slimebot/commands/level/card/CardCommand.java
@@ -48,6 +48,16 @@ public class CardCommand {
 
 	}
 
+	@ApplicationCommand(name = "reset", description = "Setzt deine Rankcard zurück")
+	public static class ResetCommand {
+		@ApplicationCommandMethod
+		public void performCommand(SlashCommandInteractionEvent event) {
+			Main.discordUtils.getUIManager().createMenu()
+					.addFrame("main", ResetWarningFrame::new)
+					.start(new CallbackState(event), "main");
+		}
+	}
+
 	@ApplicationCommand(name = "info", description = "Zeigt deine aktuellen Rankcard Optionen an")
 	public static class InfoCommand {
 

--- a/src/main/java/com/slimebot/commands/level/card/frame/ResetWarningFrame.java
+++ b/src/main/java/com/slimebot/commands/level/card/frame/ResetWarningFrame.java
@@ -35,12 +35,15 @@ public class ResetWarningFrame extends CardFrame {
 	public Collection<ComponentRow> getComponents(CardComponent COMPONENTS) {
 		return List.of(
 				ComponentRow.of(COMPONENTS.BACK(),
-						new ButtonComponent("reset", ButtonColor.RED, Emoji.fromUnicode("✔")).addHandler((m, event) ->
-								Main.database.run(handle -> handle.createUpdate("delete from cardprofile where guild = :guild and \"user\" = :user")
-										.bind("guild", event.getGuild().getIdLong())
-										.bind("user", event.getUser().getIdLong())
-								)
-						))
+				new ButtonComponent("reset", ButtonColor.RED, Emoji.fromUnicode("✔")).addHandler((m, event) -> {
+					m.setLoading();
+					Main.database.run(handle -> handle.createUpdate("delete from cardprofile where guild = :guild and \"user\" = :user")
+							.bind("guild", event.getGuild().getIdLong())
+							.bind("user", event.getUser().getIdLong())
+							.execute()
+					);
+					m.display("main");
+				}))
 		);
 	}
 }

--- a/src/main/java/com/slimebot/commands/level/card/frame/ResetWarningFrame.java
+++ b/src/main/java/com/slimebot/commands/level/card/frame/ResetWarningFrame.java
@@ -1,7 +1,7 @@
 package com.slimebot.commands.level.card.frame;
 
 import com.slimebot.commands.level.card.CardComponent;
-import com.slimebot.level.profile.CardProfile;
+import com.slimebot.main.Main;
 import de.mineking.discord.ui.Menu;
 import de.mineking.discord.ui.components.ComponentRow;
 import de.mineking.discord.ui.components.button.ButtonColor;
@@ -33,8 +33,14 @@ public class ResetWarningFrame extends CardFrame {
 
 	@Override
 	public Collection<ComponentRow> getComponents(CardComponent COMPONENTS) {
-		return List.of(ComponentRow.of(COMPONENTS.BACK(), new ButtonComponent("reset", ButtonColor.RED, Emoji.fromUnicode("✔")).addHandler((m, event) -> {
-			new CardProfile(event.getGuild().getIdLong(), event.getUser().getIdLong()).save();
-		})));
+		return List.of(
+				ComponentRow.of(COMPONENTS.BACK(),
+						new ButtonComponent("reset", ButtonColor.RED, Emoji.fromUnicode("✔")).addHandler((m, event) ->
+								Main.database.run(handle -> handle.createUpdate("delete from cardprofile where guild = :guild and \"user\" = :user")
+										.bind("guild", event.getGuild().getIdLong())
+										.bind("user", event.getUser().getIdLong())
+								)
+						))
+		);
 	}
 }

--- a/src/main/java/com/slimebot/level/RankCard.java
+++ b/src/main/java/com/slimebot/level/RankCard.java
@@ -12,6 +12,9 @@ import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.util.Map;
 
@@ -81,9 +84,19 @@ public class RankCard extends Graphic {
 		//Draw background
 		BufferedImage backgroundImage = null;
 		try {
-			if (!bg.imageURL().isBlank()) backgroundImage = ImageIO.read(new URL(bg.imageURL()));
-		} catch (Exception ignored) {
-		}   //ignored because it wil be thrown every time a invalid url is passed.
+			if (!bg.imageURL().isBlank()) {
+				var url = new URL(bg.imageURL());
+				var con = (HttpURLConnection) url.openConnection();
+
+				con.setRequestProperty("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/117.0");
+
+				con.setConnectTimeout(5000);
+				con.setReadTimeout(5000);
+
+				backgroundImage = ImageIO.read(con.getInputStream());
+			}
+		} catch (MalformedURLException | SocketTimeoutException ignored) {
+		}   //ignored because it wil be thrown every time an invalid url is passed.
 
 		Color borderColor = bg.border().color();
 		graphics2D.setColor(new Color(borderColor.getRed(), borderColor.getGreen(), borderColor.getBlue(), backgroundImage == null ? bg.color().getAlpha() : 255));


### PR DESCRIPTION
## Checklist

 - [x] Read [Contribution Guidelines](https://github.com/SlimeCloud/java-SlimeBot#-contributing) and [Style Guides](https://github.com/SlimeCloud/java-SlimeBot#-style-guide)
 - [x] Test the Code
 - [x] This PR is ready to review and merge

## Description
This adds a command that allows users to reset their card for the case that rendering the card doesn't work anymore which would make it impossible toi access the menu where you could use the reset button.

This also adds a User-Agent header to the image requests which fixes some urls where the server requires this header to work properly. To handle timeouts, the requests will now stop if downloading the image takes to long.

## Related Issue
Is this PR related to an [issue](https://github.com/SlimeCloud/java-SlimeBot/issues)?

## Other Information
