### PR TITLE
Set embed image when quoting a message with image attachment

### DIFF
--- a/src/main/java/com/slimebot/commands/QuoteMessageCommand.java
+++ b/src/main/java/com/slimebot/commands/QuoteMessageCommand.java
@@ -12,7 +12,7 @@ public class QuoteMessageCommand {
 		QuoteCommand.quote(event,
 				event.getTarget().getMember(),
 				event.getTarget().getContentRaw(),
-				event.getTarget().getJumpUrl(),
+				event.getTarget(),
 				event.getTarget().getTimeCreated()
 		);
 	}


### PR DESCRIPTION
## Checklist

 - [x] Read [Contribution Guidelines](https://github.com/SlimeCloud/java-SlimeBot#-contributing) and [Style Guides](https://github.com/SlimeCloud/java-SlimeBot#-style-guide)
 - [x] Test the Code
 - [x] This PR is ready to review and merge

## Description
This set the `image` property of the quote embed to the attachment url of the first image attachment in the quoted message.

## Related Issue
Resolves #137 
