### PR TITLE
Ignore UNKNOWN_MESSAGE errors when trying to delete threads

### DIFF
--- a/src/main/java/com/slimebot/events/AutoDeleteListener.java
+++ b/src/main/java/com/slimebot/events/AutoDeleteListener.java
@@ -14,7 +14,6 @@ import net.dv8tion.jda.api.events.channel.ChannelCreateEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.requests.RestAction;
-import net.dv8tion.jda.internal.requests.CompletedRestAction;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.EnumSet;
@@ -43,7 +42,8 @@ public class AutoDeleteListener extends ListenerAdapter {
 
 	private RestAction<Boolean> buildThreadDelete(ThreadChannel thread) {
 		return thread.retrieveStartMessage()
-				.flatMap(mes -> shouldDelete(mes, thread.getParentChannel())
+				.mapToResult()
+				.flatMap(res -> res.isSuccess() && shouldDelete(res.get(), thread.getParentChannel())
 						? thread.delete().map(x -> true)
 						: Main.emptyAction(false)
 				);


### PR DESCRIPTION
## Checklist

 - [ x Read [Contribution Guidelines](https://github.com/SlimeCloud/java-SlimeBot#-contributing) and [Style Guides](https://github.com/SlimeCloud/java-SlimeBot#-style-guide)
 - [x] Test the Code
 - [x] This PR is ready to review and merge

## Description
Uses mapToResult to ignore UNKNOWN_MESSAGE errors in autodelete. This happens, when there is no start message