### PR TITLE
Add DataListener to collect data for Discord Wrapped

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation 'net.dv8tion:JDA:5.0.0-beta.18'
 
     implementation 'de.mineking:DiscordUtils:3.6.0'
-    implementation 'de.mineking:JavaUtils:1.0.7'
+    implementation 'de.mineking:JavaUtils:1.0.9'
     implementation 'de.cyklon:JEvent:1.0.2'
 
     implementation 'se.michaelthelin.spotify:spotify-web-api-java:8.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,8 @@ repositories {
     mavenCentral()
     maven { url 'https://maven.mineking.dev/releases' }
     maven { url 'https://maven.mineking.dev/snapshots' }
+
+    maven { url 'https://jitpack.io/' }
 }
 
 dependencies {
@@ -27,6 +29,7 @@ dependencies {
     implementation 'de.cyklon:JEvent:1.0.2'
 
     implementation 'se.michaelthelin.spotify:spotify-web-api-java:8.0.0'
+    implementation 'com.github.minndevelopment:emoji-java:master-SNAPSHOT'
     implementation 'org.kohsuke:github-api:1.315'
 
     implementation 'io.github.cdimascio:java-dotenv:5.1.1'

--- a/src/main/java/de/slimecloud/slimeball/features/alerts/HolidayAlert.java
+++ b/src/main/java/de/slimecloud/slimeball/features/alerts/HolidayAlert.java
@@ -21,7 +21,7 @@ public class HolidayAlert {
 	public final static String apiHost = "https://ferien-api.de/";
 	public final static Route apiRoute = Route.get("api/v1/holidays");
 
-	private final static DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+	public final static DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
 	private final SlimeBot bot;
 	private final HttpHost host;

--- a/src/main/java/de/slimecloud/slimeball/features/fdmds/FdmdsCommand.java
+++ b/src/main/java/de/slimecloud/slimeball/features/fdmds/FdmdsCommand.java
@@ -10,6 +10,7 @@ import de.mineking.discordutils.events.Listener;
 import de.mineking.discordutils.events.handlers.ButtonHandler;
 import de.mineking.discordutils.events.handlers.ModalHandler;
 import de.slimecloud.slimeball.config.GuildConfig;
+import de.slimecloud.slimeball.features.github.ContributorCommand;
 import de.slimecloud.slimeball.main.SlimeBot;
 import de.slimecloud.slimeball.main.SlimeEmoji;
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -63,6 +64,11 @@ public class FdmdsCommand {
 	public void handleFdmdsModal(@NotNull SlimeBot bot, @NotNull ModalInteractionEvent event) {
 		String question = event.getValue("question").getAsString();
 		String[] temp = event.getValue("choices").getAsString().split("\n");
+
+		if(event.getModalId().contains("send")) {
+			//Call event
+			new FdmdsSubmitedEvent(event.getMember(), question).callEvent();
+		}
 
 		//Verify input
 		if (temp.length <= 1) {
@@ -135,6 +141,10 @@ public class FdmdsCommand {
 			String choices = embed.getFields().get(1).getValue();
 
 			if (embed.getAuthor() != null) {
+				//Call event
+				new FdmdsCreateEvent(ContributorCommand.getUser(embed), event.getMember(), question).callEvent();
+
+				//Create and send embed
 				EmbedBuilder builder = new EmbedBuilder()
 						.setColor(bot.getColor(event.getGuild()))
 						.setAuthor(embed.getAuthor().getName(), embed.getAuthor().getUrl(), embed.getAuthor().getIconUrl())
@@ -145,8 +155,12 @@ public class FdmdsCommand {
 						.setContent(fdmds.getRole().map(Role::getAsMention).orElse(null))
 						.addActionRow(Button.secondary("fdmds:create", "Frage einreichen"))
 						.queue(m -> {
-							for (int i = 0; i < choices.lines().count(); i++)
-								m.addReaction(SlimeEmoji.number(i + 1).getEmoji(event.getGuild())).queue();
+							//Add reactions
+							for (int i = 0; i < choices.lines().count(); i++) m.addReaction(SlimeEmoji.number(i + 1).getEmoji(event.getGuild())).queue();
+
+							//Create thread
+							m.createThreadChannel("Unterhaltet euch über diese Frage!").queue();
+
 							event.reply("Frage verschickt!").setEphemeral(true).queue();
 						});
 			}

--- a/src/main/java/de/slimecloud/slimeball/features/fdmds/FdmdsCreateEvent.java
+++ b/src/main/java/de/slimecloud/slimeball/features/fdmds/FdmdsCreateEvent.java
@@ -1,0 +1,16 @@
+package de.slimecloud.slimeball.features.fdmds;
+
+import de.cyklon.jevent.CancellableEvent;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.UserSnowflake;
+
+@Getter
+@AllArgsConstructor
+public class FdmdsCreateEvent extends CancellableEvent {
+	private final UserSnowflake user;
+	private final Member team;
+
+	private final String message;
+}

--- a/src/main/java/de/slimecloud/slimeball/features/fdmds/FdmdsSubmitedEvent.java
+++ b/src/main/java/de/slimecloud/slimeball/features/fdmds/FdmdsSubmitedEvent.java
@@ -1,0 +1,13 @@
+package de.slimecloud.slimeball.features.fdmds;
+
+import de.cyklon.jevent.CancellableEvent;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.dv8tion.jda.api.entities.Member;
+
+@Getter
+@AllArgsConstructor
+public class FdmdsSubmitedEvent extends CancellableEvent {
+	private final Member user;
+	private final String question;
+}

--- a/src/main/java/de/slimecloud/slimeball/features/level/Level.java
+++ b/src/main/java/de/slimecloud/slimeball/features/level/Level.java
@@ -9,28 +9,23 @@ import lombok.Getter;
 import net.dv8tion.jda.api.entities.UserSnowflake;
 import org.jetbrains.annotations.NotNull;
 
+@Getter
 @AllArgsConstructor
 public class Level implements DataClass<Level>, Comparable<Level> {
 	private final SlimeBot bot;
 
 	@Column(key = true)
-	@Getter
 	private final long guild;
-
 	@Column(key = true)
-	@Getter
 	private final UserSnowflake user;
 
 	@Column
-	@Getter
 	private final int level;
 
 	@Column
-	@Getter
 	private final int xp;
 
 	@Column
-	@Getter
 	private final int messages;
 
 	public Level(@NotNull SlimeBot bot) {

--- a/src/main/java/de/slimecloud/slimeball/features/wrapped/DataListener.java
+++ b/src/main/java/de/slimecloud/slimeball/features/wrapped/DataListener.java
@@ -1,0 +1,148 @@
+package de.slimecloud.slimeball.features.wrapped;
+
+import de.cyklon.jevent.EventHandler;
+import de.cyklon.jevent.JEvent;
+import de.mineking.javautils.database.TypeMapper;
+import de.slimecloud.slimeball.features.fdmds.FdmdsConfig;
+import de.slimecloud.slimeball.features.fdmds.FdmdsCreateEvent;
+import de.slimecloud.slimeball.features.fdmds.FdmdsSubmitedEvent;
+import de.slimecloud.slimeball.main.SlimeBot;
+import de.slimecloud.slimeball.util.StringUtil;
+import net.dv8tion.jda.api.entities.UserSnowflake;
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
+import net.dv8tion.jda.api.entities.emoji.CustomEmoji;
+import net.dv8tion.jda.api.events.channel.ChannelDeleteEvent;
+import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.events.session.ReadyEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.apache.commons.collections4.Bag;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class DataListener extends ListenerAdapter {
+	private final SlimeBot bot;
+	private final Map<Long, Long> voiceUsers = new HashMap<>();
+
+	public DataListener(@NotNull SlimeBot bot) {
+		this.bot = bot;
+		JEvent.getManager().registerListener(this);
+	}
+
+	@Override
+	public void onReady(@NotNull ReadyEvent event) {
+		//Add current voice users
+		bot.getJda().getVoiceChannels().forEach(channel -> channel.getMembers().forEach(m -> {
+			if (m.getUser().isBot()) return;
+			voiceUsers.put(m.getIdLong(), channel.getIdLong());
+		}));
+
+		//Start schedule
+		bot.getExecutor().scheduleAtFixedRate(() -> voiceUsers.forEach((user, channel) -> {
+			//Read current data
+			WrappedData data = bot.getWrappedData().getData(bot.getJda().getVoiceChannelById(channel).getGuild().getIdLong(), UserSnowflake.fromId(user));
+
+			data.getVoice().compute(String.valueOf(channel), (k, v) -> v == null ? 1 : v + 1);
+
+			//Save changes
+			data.update();
+		}), 0, 1, TimeUnit.MINUTES);
+	}
+
+	@Override
+	public void onMessageReceived(@NotNull MessageReceivedEvent event) {
+		if (!event.isFromGuild()) return;
+		if (event.getAuthor().isBot()) return;
+		if (event.isWebhookMessage()) return;
+
+		//Load current data
+		WrappedData data = bot.getWrappedData().getData(event.getMember());
+
+		//Save message in corresponding channel
+		data.getMessages().compute(event.getMessage().getChannelId(), (k, v) -> v == null ? 1 : v + 1);
+
+		//Save custom emoji usages
+		Bag<CustomEmoji> emojis = event.getMessage().getMentions().getCustomEmojisBag();
+		emojis.uniqueSet().forEach(emoji -> data.getEmotes().compute(emoji.getId(), (k, v) -> v == null ? emojis.getCount(emoji) : v + emojis.getCount(emoji)));
+
+		//Save attachments
+		data.setMedia(data.getMedia() + event.getMessage().getAttachments().size());
+
+		//Save links
+		data.setLinks(data.getLinks() + (int) Arrays.stream(event.getMessage().getContentRaw().split("\\s")).filter(StringUtil::isValidURL).count());
+
+		//Save changes
+		data.update();
+	}
+
+	@Override
+	public void onMessageReactionAdd(@NotNull MessageReactionAddEvent event) {
+		if (event.getUser().isBot()) return;
+		if (!event.isFromGuild()) return;
+
+		//Check if channel is FdmdS channel
+		if (!bot.loadGuild(event.getGuild()).getFdmds().map(FdmdsConfig::getChannel)
+				.map(channel -> channel.getIdLong() == event.getChannel().getIdLong())
+				.orElse(false)) return;
+
+		//Load current data
+		WrappedData data = bot.getWrappedData().getData(event.getMember());
+
+		//Add message. Because it is a set, duplicates don't matter
+		data.getFdmdsParticipant().add(event.getMessageIdLong());
+
+		//Save changes
+		data.update();
+	}
+
+	@EventHandler
+	public void handleFdmdsSubmitted(@NotNull FdmdsSubmitedEvent event) {
+		//Load current data
+		WrappedData data = bot.getWrappedData().getData(event.getUser());
+
+		//Update data
+		data.setFdmdsSubmitted(data.getFdmdsSubmitted() + 1);
+
+		//Save changes
+		data.update();
+	}
+
+	@EventHandler
+	public void handleFdmdsCreated(@NotNull FdmdsCreateEvent event) {
+		//Load current data
+		WrappedData data = bot.getWrappedData().getData(event.getTeam().getGuild().getIdLong(), event.getUser());
+
+		//Update data
+		data.setFdmdsAccepted(data.getFdmdsAccepted() + 1);
+
+		//Save changes
+		data.update();
+	}
+
+	@Override
+	public void onChannelDelete(@NotNull ChannelDeleteEvent event) {
+		bot.getWrappedData().getAll(event.getGuild()).forEach(data -> {
+			//Get channel voice data
+			Double minutes = data.getVoice().remove(event.getChannel().getId());
+
+			//Add to tempvoice
+			if (minutes != null) data.setTempVoice(data.getTempVoice() + (int) (double) minutes);
+
+			//Save changes
+			data.update();
+		});
+	}
+
+	@Override
+	public void onGuildVoiceUpdate(@NotNull GuildVoiceUpdateEvent event) {
+		if (event.getMember().getUser().isBot()) return;
+
+		if (event.getChannelJoined() != null && event.getChannelJoined() instanceof VoiceChannel c) voiceUsers.put(event.getMember().getIdLong(), c.getIdLong());
+		else voiceUsers.remove(event.getMember().getIdLong());
+	}
+}

--- a/src/main/java/de/slimecloud/slimeball/features/wrapped/DataListener.java
+++ b/src/main/java/de/slimecloud/slimeball/features/wrapped/DataListener.java
@@ -78,6 +78,9 @@ public class DataListener extends ListenerAdapter {
 		//Save links
 		data.setLinks(data.getLinks() + (int) Arrays.stream(event.getMessage().getContentRaw().split("\\s")).filter(StringUtil::isValidURL).count());
 
+		//Save word count
+		data.getWordCount().add(event.getMessage().getContentRaw().split("\\s").length);
+
 		//Save changes
 		data.update();
 	}

--- a/src/main/java/de/slimecloud/slimeball/features/wrapped/DataListener.java
+++ b/src/main/java/de/slimecloud/slimeball/features/wrapped/DataListener.java
@@ -79,7 +79,7 @@ public class DataListener extends ListenerAdapter {
 		data.setLinks(data.getLinks() + (int) Arrays.stream(event.getMessage().getContentRaw().split("\\s")).filter(StringUtil::isValidURL).count());
 
 		//Save word count
-		data.getWordCount().add(event.getMessage().getContentRaw().split("\\s").length);
+		data.getWordCount().add(event.getMessage().getContentRaw().split("\\s+").length);
 
 		//Save changes
 		data.update();

--- a/src/main/java/de/slimecloud/slimeball/features/wrapped/DataListener.java
+++ b/src/main/java/de/slimecloud/slimeball/features/wrapped/DataListener.java
@@ -9,6 +9,7 @@ import de.slimecloud.slimeball.features.fdmds.FdmdsSubmitedEvent;
 import de.slimecloud.slimeball.main.SlimeBot;
 import de.slimecloud.slimeball.util.StringUtil;
 import net.dv8tion.jda.api.entities.UserSnowflake;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
 import net.dv8tion.jda.api.entities.emoji.CustomEmoji;
 import net.dv8tion.jda.api.events.channel.ChannelDeleteEvent;
@@ -64,7 +65,7 @@ public class DataListener extends ListenerAdapter {
 		WrappedData data = bot.getWrappedData().getData(event.getMember());
 
 		//Save message in corresponding channel
-		data.getMessages().compute(event.getMessage().getChannelId(), (k, v) -> v == null ? 1 : v + 1);
+		data.getMessages().compute(event.getChannel() instanceof ThreadChannel tc ? tc.getParentChannel().getId() : event.getChannel().getId(), (k, v) -> v == null ? 1 : v + 1);
 
 		//Save custom emoji usages
 		Bag<CustomEmoji> emojis = event.getMessage().getMentions().getCustomEmojisBag();

--- a/src/main/java/de/slimecloud/slimeball/features/wrapped/DataListener.java
+++ b/src/main/java/de/slimecloud/slimeball/features/wrapped/DataListener.java
@@ -79,11 +79,19 @@ public class DataListener extends ListenerAdapter {
 		//Save attachments
 		data.setMedia(data.getMedia() + event.getMessage().getAttachments().size());
 
-		//Save links
-		data.setLinks(data.getLinks() + (int) Arrays.stream(event.getMessage().getContentRaw().split("\\s")).filter(StringUtil::isValidURL).count());
+		//Save links & wordcount
+		int links = 0;
+		int words = 0;
 
-		//Save word count
-		data.getWordCount().add(event.getMessage().getContentRaw().split("\\s+").length);
+		for(String s : event.getMessage().getContentRaw().split("\\s+")) {
+			if(s.isBlank()) continue;
+
+			if(StringUtil.isValidURL(s)) links++;
+			else words++;
+		}
+
+		data.setLinks(data.getLinks() + links);
+		data.getWordCount().add(words);
 
 		//Save changes
 		data.update();

--- a/src/main/java/de/slimecloud/slimeball/features/wrapped/DataListener.java
+++ b/src/main/java/de/slimecloud/slimeball/features/wrapped/DataListener.java
@@ -3,9 +3,11 @@ package de.slimecloud.slimeball.features.wrapped;
 import com.vdurmont.emoji.EmojiParser;
 import de.cyklon.jevent.EventHandler;
 import de.cyklon.jevent.JEvent;
+import de.slimecloud.slimeball.features.alerts.HolidayAlert;
 import de.slimecloud.slimeball.features.fdmds.FdmdsConfig;
 import de.slimecloud.slimeball.features.fdmds.FdmdsCreateEvent;
 import de.slimecloud.slimeball.features.fdmds.FdmdsSubmitedEvent;
+import de.slimecloud.slimeball.features.level.UserGainXPEvent;
 import de.slimecloud.slimeball.main.SlimeBot;
 import de.slimecloud.slimeball.util.StringUtil;
 import net.dv8tion.jda.api.entities.UserSnowflake;
@@ -21,6 +23,7 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.apache.commons.collections4.Bag;
 import org.jetbrains.annotations.NotNull;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -128,6 +131,20 @@ public class DataListener extends ListenerAdapter {
 
 		//Update data
 		data.setFdmdsAccepted(data.getFdmdsAccepted() + 1);
+
+		//Save changes
+		data.update();
+	}
+
+	@EventHandler
+	public void onXp(@NotNull UserGainXPEvent event) {
+		//Load current data
+		WrappedData data = bot.getWrappedData().getData(event.getUser().getGuild().getIdLong(), event.getUser());
+
+		int delta = event.getNewXp() - event.getOldXp();
+
+		//Update data
+		data.getXpPerDay().compute(HolidayAlert.formatter.format(LocalDateTime.now()), (k, v) -> v == null ? delta : v + delta);
 
 		//Save changes
 		data.update();

--- a/src/main/java/de/slimecloud/slimeball/features/wrapped/WrappedData.java
+++ b/src/main/java/de/slimecloud/slimeball/features/wrapped/WrappedData.java
@@ -55,6 +55,10 @@ public class WrappedData implements DataClass<WrappedData> {
 	@Column
 	private Set<Long> fdmdsParticipant = new HashSet<>();
 
+	@Column
+	@Json
+	private Map<String, Double> xpPerDay = new HashMap<>();
+
 	public WrappedData(@NotNull SlimeBot bot) {
 		this(bot, 0, null);
 	}

--- a/src/main/java/de/slimecloud/slimeball/features/wrapped/WrappedData.java
+++ b/src/main/java/de/slimecloud/slimeball/features/wrapped/WrappedData.java
@@ -12,10 +12,7 @@ import lombok.experimental.Accessors;
 import net.dv8tion.jda.api.entities.UserSnowflake;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 @Getter
 @Setter
@@ -36,6 +33,9 @@ public class WrappedData implements DataClass<WrappedData> {
 	@Column
 	@Json
 	private Map<String, Double> emotes = new HashMap<>();
+
+	@Column
+	private List<Integer> wordCount = new ArrayList<>();
 
 	@Column
 	private int media = 0;

--- a/src/main/java/de/slimecloud/slimeball/features/wrapped/WrappedData.java
+++ b/src/main/java/de/slimecloud/slimeball/features/wrapped/WrappedData.java
@@ -1,0 +1,72 @@
+package de.slimecloud.slimeball.features.wrapped;
+
+import de.mineking.javautils.database.Column;
+import de.mineking.javautils.database.DataClass;
+import de.mineking.javautils.database.Json;
+import de.mineking.javautils.database.Table;
+import de.slimecloud.slimeball.main.SlimeBot;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import net.dv8tion.jda.api.entities.UserSnowflake;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@RequiredArgsConstructor
+public class WrappedData implements DataClass<WrappedData> {
+	private final SlimeBot bot;
+
+	@Column(key = true)
+	private final long guild;
+	@Column(key = true)
+	private final UserSnowflake user;
+
+	@Column
+	@Json
+	//Using String, Double here instead of Long, Integer because GSON refuses to deserialize it otherwise
+	private Map<String, Double> messages = new HashMap<>();
+	@Column
+	@Json
+	private Map<String, Double> emotes = new HashMap<>();
+
+	@Column
+	private int media = 0;
+	@Column
+	private int links = 0;
+
+	@Column
+	@Json
+	private Map<String, Double> voice = new HashMap<>();
+	@Column
+	private int tempVoice = 0;
+
+	@Column
+	private int fdmdsSubmitted = 0;
+	@Column
+	private int fdmdsAccepted = 0;
+	@Column
+	private Set<Long> fdmdsParticipant = new HashSet<>();
+
+	public WrappedData(@NotNull SlimeBot bot) {
+		this(bot, 0, null);
+	}
+
+	@NotNull
+	public static WrappedData empty(@NotNull SlimeBot bot, long guild, @NotNull UserSnowflake user) {
+		return new WrappedData(bot, guild, user);
+	}
+
+	@NotNull
+	@Override
+	public Table<WrappedData> getTable() {
+		return bot.getWrappedData();
+	}
+}

--- a/src/main/java/de/slimecloud/slimeball/features/wrapped/WrappedDataTable.java
+++ b/src/main/java/de/slimecloud/slimeball/features/wrapped/WrappedDataTable.java
@@ -1,0 +1,30 @@
+package de.slimecloud.slimeball.features.wrapped;
+
+import de.mineking.javautils.database.Table;
+import de.mineking.javautils.database.Where;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.UserSnowflake;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public interface WrappedDataTable extends Table<WrappedData> {
+	@NotNull
+	default WrappedData getData(long guild, UserSnowflake user) {
+		return selectOne(Where.allOf(
+				Where.equals("guild", guild),
+				Where.equals("user", user.getIdLong())
+		)).orElseGet(() -> WrappedData.empty(getManager().getData("bot"), guild, user));
+	}
+
+	@NotNull
+	default WrappedData getData(@NotNull Member member) {
+		return getData(member.getGuild().getIdLong(), member);
+	}
+
+	@NotNull
+	default List<WrappedData> getAll(@NotNull Guild guild) {
+		return selectMany(Where.equals("guild", guild.getIdLong()));
+	}
+}

--- a/src/main/java/de/slimecloud/slimeball/main/SlimeBot.java
+++ b/src/main/java/de/slimecloud/slimeball/main/SlimeBot.java
@@ -47,6 +47,9 @@ import de.slimecloud.slimeball.features.report.commands.UserReportCommand;
 import de.slimecloud.slimeball.features.report.commands.UserReportSlashCommand;
 import de.slimecloud.slimeball.features.staff.StaffMessage;
 import de.slimecloud.slimeball.features.staff.TeamMeeting;
+import de.slimecloud.slimeball.features.wrapped.DataListener;
+import de.slimecloud.slimeball.features.wrapped.WrappedData;
+import de.slimecloud.slimeball.features.wrapped.WrappedDataTable;
 import de.slimecloud.slimeball.main.extensions.ColorOptionParser;
 import de.slimecloud.slimeball.main.extensions.ColorTypeMapper;
 import de.slimecloud.slimeball.main.extensions.UserSnowflakeTypeMapper;
@@ -105,8 +108,9 @@ public class SlimeBot extends ListenerAdapter {
 	private final LevelTable level;
 	private final RankCardTable levelProfiles;
 
-	private final GitHubAPI github;
+	private final WrappedDataTable wrappedData;
 
+	private final GitHubAPI github;
 	private final Spotify spotify;
 
 	public SlimeBot(@NotNull Config config, @NotNull Dotenv credentials) throws IOException {
@@ -132,8 +136,11 @@ public class SlimeBot extends ListenerAdapter {
 			reportBlocks = (ReportBlockTable) database.getTable(ReportBlockTable.class, ReportBlock.class, ReportBlock::new, "report_blocks").createTable();
 
 			polls = (PollTable) database.getTable(PollTable.class, Poll.class, () -> new Poll(this), "polls").createTable();
+
 			level = (LevelTable) database.getTable(LevelTable.class, Level.class, () -> new Level(this), "levels").createTable();
 			levelProfiles = (RankCardTable) database.getTable(RankCardTable.class, CardProfile.class, () -> new CardProfile(this), "card_profiles").createTable();
+
+			wrappedData = (WrappedDataTable) database.getTable(WrappedDataTable.class, WrappedData.class, () -> new WrappedData(this), "wrapped_data").createTable();
 		} else {
 			logger.warn("Database credentials missing! Some features will be disabled!");
 
@@ -143,6 +150,7 @@ public class SlimeBot extends ListenerAdapter {
 			polls = null;
 			level = null;
 			levelProfiles = null;
+			wrappedData = null;
 		}
 
 		//Initialize GitHub API
@@ -179,6 +187,8 @@ public class SlimeBot extends ListenerAdapter {
 
 				.addEventListeners(new StaffMessage(this))
 				.addEventListeners(new TeamMeeting(this))
+
+				.addEventListeners(new DataListener(this))
 
 				.build();
 
@@ -233,7 +243,7 @@ public class SlimeBot extends ListenerAdapter {
 					} else logger.warn("Level system disabled due to missing database or level config");
 
 					/*
-					Automatically update commands
+					Automatically update comDiscordWrmands
 					The parameter function loads the guild configuration and provides it as cache to all commands.
 					Tish way, the configuration does not have to be reloaded for every registration check.
 


### PR DESCRIPTION
## Checklist

 - [x] Read [Contribution Guidelines](https://github.com/SlimeCloud/java-SlimeBot#-contributing) and [Style Guides](https://github.com/SlimeCloud/java-SlimeBot#-style-guide)
 - [x] Test the Code
 - [x] This PR is ready to review and merge

## Description
Adds a new database table that holds information about these statistics for users:
- Messages per channel
- Usage of custom emotes
- Links and attachments sent
- Minutes per Voice channel
- Fdmds participated, submitted fdmds and accepted fdmds

## Related Issue
resolves #153 