### PR TITLE
Make member lists sets to enforce uniqueness

### DIFF
--- a/src/main/java/de/slimecloud/slimeball/features/staff/MeetingConfig.java
+++ b/src/main/java/de/slimecloud/slimeball/features/staff/MeetingConfig.java
@@ -117,9 +117,9 @@ public class MeetingConfig extends ConfigCategory {
 
 	@NotNull
 	public MessageEditData buildMessage(@NotNull Guild guild, @NotNull Instant timestamp, @Nullable MessageEmbed current, @Nullable MeetingHandler handler) {
-		List<String> y = new ArrayList<>();
-		List<String> m = new ArrayList<>();
-		List<String> n = new ArrayList<>();
+		Set<String> y = new HashSet<>();
+		Set<String> m = new HashSet<>();
+		Set<String> n = new HashSet<>();
 
 		List<String> a = new ArrayList<>();
 
@@ -195,6 +195,6 @@ public class MeetingConfig extends ConfigCategory {
 	}
 
 	public interface MeetingHandler {
-		void handle(@NotNull List<String> y, @NotNull List<String> m, @NotNull List<String> n, @NotNull List<String> a);
+		void handle(@NotNull Set<String> y, @NotNull Set<String> m, @NotNull Set<String> n, @NotNull List<String> a);
 	}
 }


### PR DESCRIPTION
## Checklist

 - [x] Read [Contribution Guidelines](https://github.com/SlimeCloud/java-SlimeBot#-contributing) and [Style Guides](https://github.com/SlimeCloud/java-SlimeBot#-style-guide)
 - [x] Test the Code
 - [x] This PR is ready to review and merge

## Description
This fixes an issue that allowed team members to click the same button twice resulting in them being added a second time. This should now be fixed by using a `Set` instead of `List` which makes it impossible for an element to appear more than once
