### PR TITLE
Add separate config for music notification role

### DIFF
--- a/src/main/java/de/slimecloud/slimeball/features/alerts/SpotifyNotificationConfig.java
+++ b/src/main/java/de/slimecloud/slimeball/features/alerts/SpotifyNotificationConfig.java
@@ -18,8 +18,11 @@ public class SpotifyNotificationConfig extends ConfigCategory {
 	@ConfigField(name = "Podcast-Kanal", command = "podcast", description = "Kanal, in dem Benachrichtigungen über Podcast Folgen gesendet werden", type = ConfigFieldType.MESSAGE_CHANNEL)
 	private Long podcastChannel;
 
-	@ConfigField(name = "Benachrichtigungs-Rolle", command = "role", description = "Rolle, die bei neuen Spotify-Releases erwähnt wird", type = ConfigFieldType.ROLE)
-	private Long notificationRole;
+	@ConfigField(name = "Musik-Rolle", command = "music-role", description = "Rolle, die bei neuen Musik-Releases erwähnt wird", type = ConfigFieldType.ROLE)
+	private Long musicRole;
+
+	@ConfigField(name = "Podcast-Rolle", command = "podcast-role", description = "Rolle, die bei neuen Podcast Folgen erwähnt wird", type = ConfigFieldType.ROLE)
+	private Long podcastRole;
 
 	@NotNull
 	public Optional<GuildMessageChannel> getMusicChannel() {
@@ -32,7 +35,12 @@ public class SpotifyNotificationConfig extends ConfigCategory {
 	}
 
 	@NotNull
-	public Optional<Role> getRole() {
-		return Optional.ofNullable(notificationRole).map(bot.getJda()::getRoleById);
+	public Optional<Role> getMusicRole() {
+		return Optional.ofNullable(musicRole).map(bot.getJda()::getRoleById);
+	}
+
+	@NotNull
+	public Optional<Role> getPodcastRole() {
+		return Optional.ofNullable(podcastRole).map(bot.getJda()::getRoleById);
 	}
 }


### PR DESCRIPTION
## Checklist

 - [x] Read [Contribution Guidelines](https://github.com/SlimeCloud/java-SlimeBot#-contributing) and [Style Guides](https://github.com/SlimeCloud/java-SlimeBot#-style-guide)
 - [x] Test the Code
 - [x] This PR is ready to review and merge

## Description
This adds a new config field for separate roles for music and podcast notifications
