### PR TITLE
Add poll name display and PollEditCommand

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ String lombokDependency = 'org.projectlombok:lombok:1.18.30'
 dependencies {
     implementation 'net.dv8tion:JDA:5.0.0-beta.21'
 
-    implementation('de.mineking:DiscordUtils:3.8.1')
+    implementation('de.mineking:DiscordUtils:f577623')
     implementation 'de.mineking:JavaUtils:8b4387d'
     implementation 'de.cyklon:ReflectionUtils:57d42d8'
     implementation 'de.cyklon:JEvent:62448c4'

--- a/src/main/java/de/slimecloud/slimeball/features/poll/Poll.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/Poll.java
@@ -10,6 +10,7 @@ import de.slimecloud.slimeball.util.StringUtil;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
@@ -30,9 +31,11 @@ public class Poll implements DataClass<Poll> {
 	@Column(key = true)
 	private long id;
 
+	@Setter
 	@Column
 	private int max;
 
+	@Setter
 	@Column
 	private boolean names;
 

--- a/src/main/java/de/slimecloud/slimeball/features/poll/Poll.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/Poll.java
@@ -5,12 +5,16 @@ import de.mineking.javautils.database.DataClass;
 import de.mineking.javautils.database.Json;
 import de.mineking.javautils.database.Table;
 import de.slimecloud.slimeball.main.SlimeBot;
+import de.slimecloud.slimeball.main.SlimeEmoji;
 import de.slimecloud.slimeball.util.StringUtil;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.emoji.Emoji;
+import net.dv8tion.jda.api.interactions.components.selections.SelectOption;
+import net.dv8tion.jda.api.interactions.components.selections.StringSelectMenu;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -88,5 +92,22 @@ public class Poll implements DataClass<Poll> {
 		});
 
 		return "```ansi\n" + StringUtils.abbreviate(result.toString(), 4000) + "```\n" + new HashSet<>(participants).size() + " Teilnehmer" + (max > 1 ? ", " + participants.size() + " Stimmen, Maximal **" + max + "** Stimmen pro Nutzer" : "");
+	}
+
+	@NotNull
+	public StringSelectMenu buildMenu(@NotNull Guild guild) {
+		AtomicInteger i = new AtomicInteger();
+		return StringSelectMenu.create("poll:select")
+				.setPlaceholder("Wähle weise")
+				.addOptions(values.keySet().stream()
+						.map(s -> SelectOption.of(StringUtils.abbreviate(s, SelectOption.LABEL_MAX_LENGTH), String.valueOf(i.get()))
+								//Number keycap emoji
+								.withEmoji(SlimeEmoji.number(i.incrementAndGet()).getEmoji(guild))
+						)
+						.toList()
+				)
+				.addOptions(SelectOption.of("Auswahl aufheben", "-1").withEmoji(Emoji.fromFormatted("❌")))
+				.setMaxValues(max)
+				.build();
 	}
 }

--- a/src/main/java/de/slimecloud/slimeball/features/poll/Poll.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/Poll.java
@@ -94,7 +94,7 @@ public class Poll implements DataClass<Poll> {
 			if (maxLength.get() > 8) result.append("\n");
 		});
 
-		return "```ansi\n" + StringUtils.abbreviate(result.toString(), 4000) + "```\n" + new HashSet<>(participants).size() + " Teilnehmer" + (max > 1 ? ", " + participants.size() + " Stimmen, Maximal **" + max + "** Stimmen pro Nutzer" : "");
+		return "```ansi\n" + StringUtils.abbreviate(result.toString(), 3500) + "```\n" + new HashSet<>(participants).size() + " Teilnehmer" + (max > 1 ? ", " + participants.size() + " Stimmen, Maximal **" + max + "** Stimmen pro Nutzer" : "");
 	}
 
 	@NotNull

--- a/src/main/java/de/slimecloud/slimeball/features/poll/Poll.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/Poll.java
@@ -7,15 +7,17 @@ import de.mineking.javautils.database.Table;
 import de.slimecloud.slimeball.main.SlimeBot;
 import de.slimecloud.slimeball.util.StringUtil;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+@Getter
 @RequiredArgsConstructor
 @AllArgsConstructor
 public class Poll implements DataClass<Poll> {
@@ -28,6 +30,9 @@ public class Poll implements DataClass<Poll> {
 	private int max;
 
 	@Column
+	private boolean names;
+
+	@Column
 	@Json
 	private LinkedHashMap<String, List<String>> values;
 
@@ -38,7 +43,7 @@ public class Poll implements DataClass<Poll> {
 	}
 
 	@NotNull
-	public Poll updateSelection(String user, @NotNull List<Integer> selected) {
+	public Poll updateSelection(@NotNull String user, @NotNull List<Integer> selected) {
 		AtomicInteger i = new AtomicInteger();
 
 		values.forEach((name, values) -> {
@@ -49,7 +54,8 @@ public class Poll implements DataClass<Poll> {
 		return this;
 	}
 
-	public String buildChoices() {
+	@NotNull
+	public String buildChoices(@NotNull Guild guild) {
 		StringBuilder result = new StringBuilder();
 
 		AtomicInteger maxLength = new AtomicInteger();
@@ -66,14 +72,21 @@ public class Poll implements DataClass<Poll> {
 
 			result.append("\033[1m").append(StringUtil.padRight(name, maxLength.get())).append("\033[0m").append(maxLength.get() > 8 ? "\n" : ": ")
 					//Bar
-					.append("[").append(StringUtil.createProgressBar(percentage, 30)).append("]")
+					.append("[").append(StringUtil.createProgressBar(percentage, 20)).append("]")
 					//Display percentage
 					.append(" \033[34;1m(").append((int) (percentage * 100)).append("%, ").append(values.size()).append(" Stimmen)\033[0m")
 					.append("\n");
 
+			if (names) {
+				StringBuilder names = new StringBuilder();
+				values.forEach(n -> names.append("- ").append(Optional.ofNullable(guild.getMemberById(n)).map(Member::getEffectiveName).orElse("Unbekannt")).append("\n"));
+
+				result.append(StringUtils.abbreviate(names.toString(), 500)).append("\n");
+			}
+
 			if (maxLength.get() > 8) result.append("\n");
 		});
 
-		return "```ansi\n" + result + "```\n" + new HashSet<>(participants).size() + " Teilnehmer" + (max > 1 ? ", " + participants.size() + " Stimmen" : "");
+		return "```ansi\n" + StringUtils.abbreviate(result.toString(), 4000) + "```\n" + new HashSet<>(participants).size() + " Teilnehmer" + (max > 1 ? ", " + participants.size() + " Stimmen, Maximal **" + max + "** Stimmen pro Nutzer" : "");
 	}
 }

--- a/src/main/java/de/slimecloud/slimeball/features/poll/PollCommand.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/PollCommand.java
@@ -28,7 +28,7 @@ public class PollCommand {
 	public void performCommand(@NotNull SlimeBot bot, @NotNull SlashCommandInteractionEvent event,
 	                           @Option(description = "Die Frage") String question,
 	                           @OptionArray(minCount = 2, maxCount = 5) @Option(name = "choice", description = "Die Auswahlmöglichkeiten", maxLength = 90) String[] options,
-	                           @IntegerDefault(1) @Option(description = "Die maximale Anzahl pro Nutzer", required = false, minValue = 1) int max,
+	                           @IntegerDefault(1) @Option(description = "Die maximale Anzahl pro Nutzer", required = false, minValue = 1, maxValue = 25) int max,
 	                           @Option(description = "Rolle, die erwähnt wird", required = false) Role role,
                                @BooleanDefault(false) @Option(description = "Namen der Nutzer anzeigen? (Nur bei internen Abstimmungen!)", required = false) boolean names
 	) {

--- a/src/main/java/de/slimecloud/slimeball/features/poll/PollCommand.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/PollCommand.java
@@ -44,11 +44,10 @@ public class PollCommand {
 							.setTitle("\uD83D\uDCCA  Abstimmung")
 							.setAuthor(event.getMember().getEffectiveName(), null, event.getMember().getEffectiveAvatarUrl())
 							.setColor(bot.getColor(event.getGuild()))
-							.setDescription(question)
-							.addField(
-									"Ergebnisse",
-									poll.buildChoices(event.getGuild()),
-									false
+							.setDescription(question + "\n")
+							.appendDescription(
+									"## Ergebnisse\n\n" +
+									poll.buildChoices(event.getGuild())
 							)
 							.setFooter(max == 1 ? null : "Maximale Stimmzahl: " + max)
 							.build()

--- a/src/main/java/de/slimecloud/slimeball/features/poll/PollCommand.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/PollCommand.java
@@ -46,7 +46,7 @@ public class PollCommand {
 							.setColor(bot.getColor(event.getGuild()))
 							.setDescription(question + "\n")
 							.appendDescription(
-									"## Ergebnisse\n\n" +
+									"### Ergebnisse\n\n" +
 									poll.buildChoices(event.getGuild())
 							)
 							.setFooter(max == 1 ? null : "Maximale Stimmzahl: " + max)

--- a/src/main/java/de/slimecloud/slimeball/features/poll/PollCommand.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/PollCommand.java
@@ -7,37 +7,14 @@ import de.mineking.discordutils.commands.option.Option;
 import de.mineking.discordutils.commands.option.OptionArray;
 import de.mineking.discordutils.commands.option.defaultValue.BooleanDefault;
 import de.mineking.discordutils.commands.option.defaultValue.IntegerDefault;
-import de.mineking.discordutils.ui.MessageMenu;
-import de.mineking.discordutils.ui.MessageRenderer;
-import de.mineking.discordutils.ui.UIManager;
-import de.mineking.discordutils.ui.components.button.ButtonColor;
-import de.mineking.discordutils.ui.components.button.ButtonComponent;
-import de.mineking.discordutils.ui.components.button.MenuComponent;
-import de.mineking.discordutils.ui.components.button.ToggleComponent;
-import de.mineking.discordutils.ui.components.button.label.TextLabel;
-import de.mineking.discordutils.ui.components.types.ComponentRow;
-import de.mineking.discordutils.ui.modal.ModalMenu;
-import de.mineking.javautils.database.Where;
 import de.slimecloud.slimeball.main.CommandPermission;
 import de.slimecloud.slimeball.main.SlimeBot;
-import de.slimecloud.slimeball.main.SlimeEmoji;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.entities.emoji.Emoji;
-import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.InteractionHook;
-import net.dv8tion.jda.api.interactions.commands.Command;
-import net.dv8tion.jda.api.interactions.components.selections.SelectOption;
-import net.dv8tion.jda.api.interactions.components.selections.StringSelectMenu;
-import net.dv8tion.jda.api.requests.restaction.MessageEditAction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 @ApplicationCommand(name = "poll", description = "Erstellt eine Abstimmung")
 public class PollCommand {
@@ -63,7 +40,7 @@ public class PollCommand {
 					//Create poll
 					Poll poll = bot.getPolls().createPoll(mes.getIdLong(), max, names, options);
 
-					MessageEditAction temp = mes.editMessageEmbeds(new EmbedBuilder()
+					return mes.editMessageEmbeds(new EmbedBuilder()
 							.setTitle("\uD83D\uDCCA  Abstimmung")
 							.setAuthor(event.getMember().getEffectiveName(), null, event.getMember().getEffectiveAvatarUrl())
 							.setColor(bot.getColor(event.getGuild()))
@@ -75,23 +52,7 @@ public class PollCommand {
 							)
 							.setFooter(max == 1 ? null : "Maximale Stimmzahl: " + max)
 							.build()
-					);
-
-					AtomicInteger i = new AtomicInteger();
-					return temp.setActionRow(
-							StringSelectMenu.create("poll:select")
-									.setPlaceholder("Wähle weise")
-									.addOptions(Arrays.stream(options)
-											.map(s -> SelectOption.of(StringUtils.abbreviate(s, SelectOption.LABEL_MAX_LENGTH), String.valueOf(i.get()))
-													//Number keycap emoji
-													.withEmoji(SlimeEmoji.number(i.incrementAndGet()).getEmoji(event.getGuild()))
-											)
-											.toList()
-									)
-									.addOptions(SelectOption.of("Auswahl aufheben", "-1").withEmoji(Emoji.fromFormatted("❌")))
-									.setMaxValues(max)
-									.build()
-					);
+					).setActionRow(poll.buildMenu(event.getGuild()));
 				})
 				.queue();
 	}

--- a/src/main/java/de/slimecloud/slimeball/features/poll/PollCommand.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/PollCommand.java
@@ -27,7 +27,7 @@ public class PollCommand {
 	@ApplicationCommandMethod
 	public void performCommand(@NotNull SlimeBot bot, @NotNull SlashCommandInteractionEvent event,
 	                           @Option(description = "Die Frage") String question,
-	                           @OptionArray(minCount = 2, maxCount = 5) @Option(name = "choice", description = "Die Auswahlmöglichkeiten") String[] options,
+	                           @OptionArray(minCount = 2, maxCount = 5) @Option(name = "choice", description = "Die Auswahlmöglichkeiten", maxLength = 90) String[] options,
 	                           @IntegerDefault(1) @Option(description = "Die maximale Anzahl pro Nutzer", required = false, minValue = 1) int max,
 	                           @Option(description = "Rolle, die erwähnt wird", required = false) Role role,
                                @BooleanDefault(false) @Option(description = "Namen der Nutzer anzeigen? (Nur bei internen Abstimmungen!)", required = false) boolean names

--- a/src/main/java/de/slimecloud/slimeball/features/poll/PollCommand.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/PollCommand.java
@@ -5,15 +5,29 @@ import de.mineking.discordutils.commands.ApplicationCommand;
 import de.mineking.discordutils.commands.ApplicationCommandMethod;
 import de.mineking.discordutils.commands.option.Option;
 import de.mineking.discordutils.commands.option.OptionArray;
+import de.mineking.discordutils.commands.option.defaultValue.BooleanDefault;
 import de.mineking.discordutils.commands.option.defaultValue.IntegerDefault;
+import de.mineking.discordutils.ui.MessageMenu;
+import de.mineking.discordutils.ui.MessageRenderer;
+import de.mineking.discordutils.ui.UIManager;
+import de.mineking.discordutils.ui.components.button.ButtonColor;
+import de.mineking.discordutils.ui.components.button.ButtonComponent;
+import de.mineking.discordutils.ui.components.button.MenuComponent;
+import de.mineking.discordutils.ui.components.button.ToggleComponent;
+import de.mineking.discordutils.ui.components.button.label.TextLabel;
+import de.mineking.discordutils.ui.components.types.ComponentRow;
+import de.mineking.discordutils.ui.modal.ModalMenu;
+import de.mineking.javautils.database.Where;
 import de.slimecloud.slimeball.main.CommandPermission;
 import de.slimecloud.slimeball.main.SlimeBot;
 import de.slimecloud.slimeball.main.SlimeEmoji;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
+import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.InteractionHook;
+import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.components.selections.SelectOption;
 import net.dv8tion.jda.api.interactions.components.selections.StringSelectMenu;
 import net.dv8tion.jda.api.requests.restaction.MessageEditAction;
@@ -22,9 +36,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-@ApplicationCommand(name = "poll", description = "Erstelle eine Abstimmung")
+@ApplicationCommand(name = "poll", description = "Erstellt eine Abstimmung")
 public class PollCommand {
 	public final CommandPermission permission = CommandPermission.TEAM;
 
@@ -37,7 +52,8 @@ public class PollCommand {
 	                           @Option(description = "Die Frage") String question,
 	                           @OptionArray(minCount = 2, maxCount = 5) @Option(name = "choice", description = "Die Auswahlmöglichkeiten") String[] options,
 	                           @IntegerDefault(1) @Option(description = "Die maximale Anzahl pro Nutzer", required = false, minValue = 1) int max,
-	                           @Option(description = "Rolle, die erwähnt wird", required = false) Role role
+	                           @Option(description = "Rolle, die erwähnt wird", required = false) Role role,
+                               @BooleanDefault(false) @Option(description = "Namen der Nutzer anzeigen? (Nur bei internen Abstimmungen!)", required = false) boolean names
 	) {
 		ReplyCallbackAction action = role == null ? event.deferReply() : event.reply(role.getAsMention());
 
@@ -45,7 +61,7 @@ public class PollCommand {
 		action.flatMap(InteractionHook::retrieveOriginal)
 				.flatMap(mes -> {
 					//Create poll
-					Poll poll = bot.getPolls().createPoll(mes.getIdLong(), max, options);
+					Poll poll = bot.getPolls().createPoll(mes.getIdLong(), max, names, options);
 
 					MessageEditAction temp = mes.editMessageEmbeds(new EmbedBuilder()
 							.setTitle("\uD83D\uDCCA  Abstimmung")
@@ -54,7 +70,7 @@ public class PollCommand {
 							.setDescription(question)
 							.addField(
 									"Ergebnisse",
-									poll.buildChoices(),
+									poll.buildChoices(event.getGuild()),
 									false
 							)
 							.setFooter(max == 1 ? null : "Maximale Stimmzahl: " + max)

--- a/src/main/java/de/slimecloud/slimeball/features/poll/PollEditCommand.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/PollEditCommand.java
@@ -113,7 +113,7 @@ public class PollEditCommand {
 						.display((GenericComponentInteractionCreateEvent) state.getEvent())
 				),
 				ComponentRow.of(
-						new MenuComponent<>(addModal, ButtonColor.GRAY, "Option hinzufügen").transfereState(),
+						new MenuComponent<>(addModal, ButtonColor.GRAY, "Option hinzufügen").transfereState().asDisabled(s -> s.<Optional<Poll>>getCache("poll").map(p -> p.getValues().size()).map(m -> m >= 25).orElse(true)),
 						new ButtonComponent("names", s -> s.<Optional<Poll>>getCache("poll").filter(Poll::isNames).map(p -> ButtonColor.GREEN).orElse(ButtonColor.GRAY), "Namen anzeigen").appendHandler(s -> {
 							s.<Optional<Poll>>getCache("poll").ifPresent(poll -> poll.setNames(!poll.isNames()).update());
 							s.update();

--- a/src/main/java/de/slimecloud/slimeball/features/poll/PollEditCommand.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/PollEditCommand.java
@@ -90,7 +90,7 @@ public class PollEditCommand {
 							s.<Optional<Poll>>getCache("poll").ifPresent(poll -> poll.setMax(poll.getMax() - 1).update());
 							s.update();
 						}),
-						new ButtonComponent("max.add", ButtonColor.BLUE, "+").appendHandler(s -> {
+						new ButtonComponent("max.add", ButtonColor.BLUE, "+").asDisabled(s -> s.<Optional<Poll>>getCache("poll").map(Poll::getMax).map(m -> m >= 25).orElse(true)).appendHandler(s -> {
 							s.<Optional<Poll>>getCache("poll").ifPresent(poll -> poll.setMax(poll.getMax() + 1).update());
 							s.update();
 						})

--- a/src/main/java/de/slimecloud/slimeball/features/poll/PollEditCommand.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/PollEditCommand.java
@@ -40,7 +40,9 @@ public class PollEditCommand {
 				"poll.options.add",
 				s -> "Option hinzufügen",
 				List.of(
-						new TextComponent("name", "Option", TextInputStyle.SHORT).setPlaceholder("Ja / Nein")
+						new TextComponent("name", "Option", TextInputStyle.SHORT)
+								.setPlaceholder("Ja / Nein")
+								.setMaxLength(90)
 				),
 				(state, response) -> {
 					Map<String, List<String>> options = state.<Map<String, List<String>>>getState("values", LinkedHashMap.class);

--- a/src/main/java/de/slimecloud/slimeball/features/poll/PollEditCommand.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/PollEditCommand.java
@@ -1,0 +1,74 @@
+package de.slimecloud.slimeball.features.poll;
+
+import de.mineking.discordutils.commands.ApplicationCommand;
+import de.mineking.discordutils.commands.ApplicationCommandMethod;
+import de.mineking.discordutils.ui.MessageMenu;
+import de.mineking.discordutils.ui.MessageRenderer;
+import de.mineking.discordutils.ui.UIManager;
+import de.mineking.discordutils.ui.components.button.ButtonColor;
+import de.mineking.discordutils.ui.components.button.ButtonComponent;
+import de.mineking.discordutils.ui.components.button.MenuComponent;
+import de.mineking.discordutils.ui.components.button.ToggleComponent;
+import de.mineking.discordutils.ui.components.button.label.TextLabel;
+import de.mineking.discordutils.ui.components.types.ComponentRow;
+import de.mineking.discordutils.ui.modal.ModalMenu;
+import de.mineking.discordutils.ui.modal.TextComponent;
+import de.mineking.javautils.database.Where;
+import de.slimecloud.slimeball.main.CommandPermission;
+import de.slimecloud.slimeball.main.SlimeBot;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.Command;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+@ApplicationCommand(name = "Abstimmung bearbeiten", type = Command.Type.MESSAGE)
+public class PollEditCommand {
+	public final CommandPermission permission = CommandPermission.ROLE_MANAGE; //This makes this command only visible for team members
+
+	private final MessageMenu menu;
+
+	public PollEditCommand(@NotNull SlimeBot bot, @NotNull UIManager manager) {
+		menu = manager.createMenu(
+				"poll.edit",
+				MessageRenderer.embed(s -> new EmbedBuilder()
+						.setColor(bot.getColor(s.getEvent().getGuild()))
+						.setTitle("Umfrage bearbeiten")
+						.setDescription("https://discord.com/channels/" + s.getEvent().getGuild().getId() + "/" + s.getEvent().getChannel().getId() + "/" + s.getState("id", String.class) + " ")
+						.appendDescription("Umfrage wird aktualisiert sobald der nächste Nutzer eine Auswahl tritt")
+						.appendDescription(bot.getPolls().getPoll(s.getState("id", long.class)).map(p -> p.buildChoices(s.getEvent().getGuild())).orElse("*Nicht gefunden*"))
+						.build()
+				),
+				ComponentRow.of(
+						new ButtonComponent("max.label", ButtonColor.GRAY, "Maximale Stimmzahl pro Nutzer").asDisabled(true),
+						new ButtonComponent("max.subtract", ButtonColor.BLUE, "-").asDisabled(s -> s.getState("max", int.class) <= 1).appendHandler(s -> {
+							s.setState("max", int.class, i -> i - 1);
+							s.update();
+						}),
+						new ButtonComponent("max.add", ButtonColor.BLUE, "+").appendHandler(s -> {
+							s.setState("max", int.class, i -> i + 1);
+							s.update();
+						})
+				),
+				ComponentRow.of(
+						new ToggleComponent("names", e -> e ? ButtonColor.GREEN : ButtonColor.GRAY, "Namen anzeigen")
+				)
+		).effect((state, name, oldValue, newValue) -> {
+			if (!bot.getPolls().getColumns().containsKey(name)) return;
+			bot.getPolls().updateField(Where.equals("id", state.getState("id", long.class)), name, newValue);
+		});
+	}
+
+	@ApplicationCommandMethod
+	public void performCommand(@NotNull SlimeBot bot, @NotNull MessageContextInteractionEvent event) {
+		bot.getPolls().getPoll(event.getTarget().getIdLong()).ifPresentOrElse(
+				poll -> menu.createState()
+						.setState("id", poll.getId())
+						.setState("names", poll.isNames())
+						.setState("max", poll.getMax())
+						.display(event),
+				() -> event.reply(":x: Abstimmung nicht gefunden!").setEphemeral(true).queue()
+		);
+	}
+}

--- a/src/main/java/de/slimecloud/slimeball/features/poll/PollListener.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/PollListener.java
@@ -51,7 +51,7 @@ public class PollListener extends ListenerAdapter {
 							false
 					)
 					.build()
-			).queue();
+			).setActionRow(poll.buildMenu(event.getGuild())).queue();
 		});
 	}
 }

--- a/src/main/java/de/slimecloud/slimeball/features/poll/PollListener.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/PollListener.java
@@ -43,10 +43,10 @@ public class PollListener extends ListenerAdapter {
 
 			//Update message
 			MessageEmbed old = event.getMessage().getEmbeds().get(0);
-			String[] temp = old.getDescription().split("## Ergebnisse\n\n", 2);
+			String[] temp = old.getDescription().split("### Ergebnisse\n\n", 2);
 			event.getHook().editOriginalEmbeds(new EmbedBuilder(old)
 					.clearFields() //To keep old polls intact
-					.setDescription((old.getFields().isEmpty() ? temp[0] : old.getDescription() + "\n") + "## Ergebnisse\n\n" + poll.buildChoices(event.getGuild()))
+					.setDescription((old.getFields().isEmpty() ? temp[0] : old.getDescription() + "\n") + "### Ergebnisse\n\n" + poll.buildChoices(event.getGuild()))
 					.build()
 			).setActionRow(poll.buildMenu(event.getGuild())).queue();
 		});

--- a/src/main/java/de/slimecloud/slimeball/features/poll/PollListener.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/PollListener.java
@@ -47,7 +47,7 @@ public class PollListener extends ListenerAdapter {
 					.clearFields()
 					.addField(
 							"Auswahlmöglichkeiten",
-							poll.buildChoices(),
+							poll.buildChoices(event.getGuild()),
 							false
 					)
 					.build()

--- a/src/main/java/de/slimecloud/slimeball/features/poll/PollListener.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/PollListener.java
@@ -46,7 +46,7 @@ public class PollListener extends ListenerAdapter {
 			String[] temp = old.getDescription().split("## Ergebnisse\n\n", 2);
 			event.getHook().editOriginalEmbeds(new EmbedBuilder(old)
 					.clearFields() //To keep old polls intact
-					.setDescription((old.getFields().isEmpty() ? temp[0] : old.getDescription()) + "## Ergebnisse\n\n" + poll.buildChoices(event.getGuild()))
+					.setDescription((old.getFields().isEmpty() ? temp[0] : old.getDescription() + "\n") + "## Ergebnisse\n\n" + poll.buildChoices(event.getGuild()))
 					.build()
 			).setActionRow(poll.buildMenu(event.getGuild())).queue();
 		});

--- a/src/main/java/de/slimecloud/slimeball/features/poll/PollListener.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/PollListener.java
@@ -43,13 +43,10 @@ public class PollListener extends ListenerAdapter {
 
 			//Update message
 			MessageEmbed old = event.getMessage().getEmbeds().get(0);
+			String[] temp = old.getDescription().split("## Ergebnisse\n\n", 2);
 			event.getHook().editOriginalEmbeds(new EmbedBuilder(old)
-					.clearFields()
-					.addField(
-							"Auswahlmöglichkeiten",
-							poll.buildChoices(event.getGuild()),
-							false
-					)
+					.clearFields() //To keep old polls intact
+					.setDescription((old.getFields().isEmpty() ? temp[0] : old.getDescription()) + "## Ergebnisse\n\n" + poll.buildChoices(event.getGuild()))
 					.build()
 			).setActionRow(poll.buildMenu(event.getGuild())).queue();
 		});

--- a/src/main/java/de/slimecloud/slimeball/features/poll/PollTable.java
+++ b/src/main/java/de/slimecloud/slimeball/features/poll/PollTable.java
@@ -12,8 +12,14 @@ import java.util.stream.Collectors;
 
 public interface PollTable extends Table<Poll> {
 	@NotNull
-	default Poll createPoll(long message, int max, String[] choices) {
-		return insert(new Poll(getManager().getData("bot"), message, max, Arrays.stream(choices).collect(Collectors.toMap(c -> c, x -> new ArrayList<>(), (x, y) -> y, LinkedHashMap::new))));
+	default Poll createPoll(long message, int max, boolean names, @NotNull String[] choices) {
+		return insert(new Poll(
+				getManager().getData("bot"),
+				message,
+				max,
+				names,
+				Arrays.stream(choices).collect(Collectors.toMap(c -> c, x -> new ArrayList<>(), (x, y) -> y, LinkedHashMap::new))
+		));
 	}
 
 	default void delete(long message) {

--- a/src/main/java/de/slimecloud/slimeball/main/SlimeBot.java
+++ b/src/main/java/de/slimecloud/slimeball/main/SlimeBot.java
@@ -39,6 +39,7 @@ import de.slimecloud.slimeball.features.moderation.MessageListener;
 import de.slimecloud.slimeball.features.moderation.TimeoutListener;
 import de.slimecloud.slimeball.features.poll.Poll;
 import de.slimecloud.slimeball.features.poll.PollCommand;
+import de.slimecloud.slimeball.features.poll.PollEditCommand;
 import de.slimecloud.slimeball.features.poll.PollTable;
 import de.slimecloud.slimeball.features.quote.QuoteCommand;
 import de.slimecloud.slimeball.features.quote.QuoteMessageCommand;
@@ -274,6 +275,7 @@ public class SlimeBot extends ListenerAdapter {
 					//Register poll commands
 					if (polls != null) {
 						manager.registerCommand(PollCommand.class);
+						manager.registerCommand(PollEditCommand.class);
 					} else logger.warn("Poll system disabled due to missing database");
 
 					//Register leveling commands


### PR DESCRIPTION
## Checklist

 - [x] Read [Contribution Guidelines](https://github.com/SlimeCloud/java-SlimeBot#-contributing) and [Style Guides](https://github.com/SlimeCloud/java-SlimeBot#-style-guide)
 - [x] Test the Code
 - [x] This PR is ready to review and merge

## Description
Adds an option to display the names of participants and a menu for editing existing polls

## Todo
- [x] Show names
- [x] Edit
- [x] Edit options

## Migration
```sql
alter table polls add names boolean;
update polls set names = false;
```