### PR TITLE
Update level roles on join

### DIFF
--- a/src/main/java/de/slimecloud/slimeball/features/level/LevelListener.java
+++ b/src/main/java/de/slimecloud/slimeball/features/level/LevelListener.java
@@ -8,6 +8,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.events.guild.GuildBanEvent;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
 import net.dv8tion.jda.api.events.guild.voice.GenericGuildVoiceEvent;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -49,6 +50,12 @@ public class LevelListener extends ListenerAdapter {
 	@Override
 	public void onGuildBan(@NotNull GuildBanEvent event) {
 		bot.getLevel().reset(event.getGuild(), event.getUser());
+	}
+
+	@Override
+	public void onGuildMemberJoin(@NotNull GuildMemberJoinEvent event) {
+		Level level = bot.getLevel().getLevel(event.getMember());
+		LevelUpListener.updateLevelRoles(bot, event.getMember(), level.getLevel());
 	}
 
 	@Override


### PR DESCRIPTION
## Checklist

 - [x] Read [Contribution Guidelines](https://github.com/SlimeCloud/java-SlimeBot#-contributing) and [Style Guides](https://github.com/SlimeCloud/java-SlimeBot#-style-guide)
 - [x] Test the Code
 - [x] This PR is ready to review and merge

## Description
This updates a members level roles on join. This fixes the issue that when members join, who have previously been on the server don't have their level role until their next level up